### PR TITLE
Export Method constructors

### DIFF
--- a/JavaScript/JQuery.hs
+++ b/JavaScript/JQuery.hs
@@ -8,7 +8,7 @@ module JavaScript.JQuery ( JQuery(..)
                          , Event(..)
                          , EventType
                          , Selector
-                         , Method
+                         , Method(..)
                          , AjaxSettings(..)
                          , AjaxResult(..)
                          , ajax


### PR DESCRIPTION
No Method constructor is used or exported besides GET. Is this intentional?
