### PR TITLE
add ajaxRaw

### DIFF
--- a/JavaScript/JQuery.hs
+++ b/JavaScript/JQuery.hs
@@ -12,6 +12,7 @@ module JavaScript.JQuery ( JQuery(..)
                          , AjaxSettings(..)
                          , AjaxResult(..)
                          , ajax
+                         , ajaxRaw
                          , HandlerSettings(..)
                          , addClass
                          , animate
@@ -245,10 +246,9 @@ instance ToJSString Method where
   toJSString PUT    = "PUT"
   toJSString DELETE = "DELETE"
 
-ajax :: Text -> [(Text,Text)] -> AjaxSettings -> IO AjaxResult
-ajax url d s = do
-  o <- newObj
-  forM_ d (\(k,v) -> F.setProp k (toJSString v) o)
+
+ajaxRaw :: Text -> JSRef a -> AjaxSettings -> IO AjaxResult
+ajaxRaw url o s = do
   os <- toJSRef s
   F.setProp ("data"::Text) o os
   arr <- jq_ajax (toJSString url) os
@@ -256,6 +256,12 @@ ajax url d s = do
   let d = if isNull dat then Nothing else Just (fromJSString dat)
   status <- fromMaybe 0 <$> (fromJSRef =<< F.getProp ("status"::Text) arr)
   return (AjaxResult status d)
+
+ajax :: Text -> [(Text,Text)] -> AjaxSettings -> IO AjaxResult
+ajax url d s = do
+  o <- newObj
+  forM_ d (\(k,v) -> F.setProp k (toJSString v) o)
+  ajaxRaw url o s
 
 data HandlerSettings = HandlerSettings { hsPreventDefault           :: Bool
                                        , hsStopPropagation          :: Bool


### PR DESCRIPTION
very tentative suggestion, more for the purpose of gathering feedback than anything.

The use case here is to be able to send json bodies rather than [(Text,Text)]. I think long term I'd probably want to take a type implementing ToJSON, but obviously you don't want to bake Aeson into this lib, so that should probably be done elsewhere.
