### PR TITLE
Generalized ajax, allows json etc

### DIFF
--- a/JavaScript/JQuery.hs
+++ b/JavaScript/JQuery.hs
@@ -229,8 +229,8 @@ data AjaxSettings = AjaxSettings { asContentType :: Maybe Text
                                  } deriving (Ord, Eq, Show, Typeable)
 
 data AjaxResult = AjaxResult { arStatus :: Int
-                             , arData   :: Maybe Text
-                             } deriving (Ord, Eq, Show, Typeable)
+                             , arData   :: Value
+                             } deriving (Eq, Show, Typeable)
 
 instance Default AjaxSettings where
   def = AjaxSettings Nothing True False GET
@@ -284,9 +284,8 @@ ajax url d s = do
                   ]
   o2 <- toJSRef o1
   arr <- jq_ajax (toJSString url) o2
-  dat <- F.getProp ("data"::Text) arr
-  let d = if isNull dat then Nothing else Just (fromJSString dat)
   status <- fromMaybe 0 <$> (fromJSRef =<< F.getProp ("status"::Text) arr)
+  d <- fromMaybe Null <$> (fromJSRef =<< F.getProp ("data"::Text) arr)
   return (AjaxResult status d)
 
 data HandlerSettings = HandlerSettings { hsPreventDefault           :: Bool

--- a/JavaScript/JQuery/Internal.hs
+++ b/JavaScript/JQuery/Internal.hs
@@ -118,13 +118,12 @@ foreign import javascript unsafe "$2.siblings($1)"                    jq_sibling
 foreign import javascript unsafe "$2.slice($1)"                       jq_slice             :: Int                  -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.slice($1,$2)"                    jq_sliceFromTo       :: Int -> Int           -> JQuery -> IO JQuery
 
-foreign import javascript interruptible "jQuery.ajax($1,$2).always(function(d,ts,xhr) {\
-                                  if(typeof(d) === 'string') {\
-                                    $c({ data: d, status: xhr.status });\
-                                   } else {\
-                                    $c({ data: null, status: d.status });\
-                                  }\
-                                });"
+foreign import javascript interruptible
+  "jQuery.ajax($1,$2).then(function(d,ts,xhr) {\
+        $c({ data: d, status: xhr.status });\
+      }).fail(function(xhr) {\
+        $c({ data: null, status: xhr.status });\
+      });"
   jq_ajax :: JSString
           -> JSRef ajaxSettings
           -> IO (JSRef ajaxResult)

--- a/ghcjs-jquery.cabal
+++ b/ghcjs-jquery.cabal
@@ -19,6 +19,7 @@ library
   exposed-modules:   JavaScript.JQuery
                      JavaScript.JQuery.Internal
   build-depends:     base ==4.7.*,
+                     aeson,
                      data-default,
                      ghcjs-base,
                      ghcjs-dom,


### PR DESCRIPTION
Similar in spirit to the PR @mwotton this generalizes ajax with a ToAjax class. Instances allow the request body to be a list of pairs (as in the original code), or a String, a Text, or an aeson Object. A suitable default content type is chosen depending on the type of the data; it can be overridden in AjaxSettings. The response can be a string or an object, and is returned as an aeson Value. Obviously this does introduce a dependency on aeson, but since ghcjs-base depends on aeson I don't see a problem with this.

I've made a yesod-based test framework for ghcjs-jquery ajax calls: https://github.com/TobyGoodwin/ghcjs-jquery-test (It's fairly minimal so far; I'm happy to accept PRs, and of course track any changes that go into ghcjs-jquery.)