### PR TITLE
Tentative fix for #14 (Add 'ready' function)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /dist/
+example/Main.js*
+.stack-work
+all.js

--- a/JavaScript/JQuery.hs
+++ b/JavaScript/JQuery.hs
@@ -14,6 +14,7 @@ module JavaScript.JQuery ( JQuery(..)
                          , AjaxResult(..)
                          , ajax
                          , HandlerSettings(..)
+                         , ready
                          , addClass
                          , animate
                          , getAttr
@@ -274,6 +275,11 @@ convertHandlerSettings (HandlerSettings pd sp sip _ ds hd) =
 
 instance Default HandlerSettings where
   def = HandlerSettings False False False True Nothing Nothing
+
+ready :: IO () -> IO ()
+ready action = do
+  clbk <- asyncCallback (const () <$> action)
+  jq_ready clbk
 
 addClass :: JSString -> JQuery -> IO JQuery
 addClass c = jq_addClass c

--- a/JavaScript/JQuery/Internal.hs
+++ b/JavaScript/JQuery/Internal.hs
@@ -3,55 +3,54 @@
 module JavaScript.JQuery.Internal where
 
 import GHCJS.DOM.Types (Element(..))
-import GHCJS.Foreign
 import GHCJS.Foreign.Callback (Callback)
-import GHCJS.Nullable
 import GHCJS.Types
 import JavaScript.Object (Object)
 
 newtype JQuery = JQuery JSVal
 newtype Event = Event JSVal
 
-foreign import javascript unsafe "$2.addClass($1)"       jq_addClass          :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$3.animate($1,$2)"     jq_animate           :: JSVal    -> JSVal    -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.attr($1)"           jq_getAttr           :: JSString             -> JQuery -> IO JSString
-foreign import javascript unsafe "$3.attr($1,$2)"        jq_setAttr           :: JSString -> JSString -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.hasClass($1)"       jq_hasClass          :: JSString             -> JQuery -> IO Bool
-foreign import javascript unsafe "$1.html()"             jq_getHtml           ::                         JQuery -> IO JSString
-foreign import javascript unsafe "$2.html($1)"           jq_setHtml           :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.prop($1)"           jq_getProp           :: JSString             -> JQuery -> IO JSString
-foreign import javascript unsafe "$3.prop($1,$2)"        jq_setProp           :: JSString -> JSString -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.removeAttr($1)"     jq_removeAttr        :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.removeClass($1)"    jq_removeClass       :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.removeProp($1)"     jq_removeProp        :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.val()"              jq_getVal            ::                         JQuery -> IO JSString
-foreign import javascript unsafe "$2.val($1)"            jq_setVal            :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.text()"             jq_getText           ::                         JQuery -> IO JSString
-foreign import javascript unsafe "$2.text($1)"           jq_setText           :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "jQuery.holdReady($1)"  jq_holdReady         :: Bool                           -> IO ()
-foreign import javascript unsafe "jQuery($1)"            jq_selectElement     :: Element                        -> IO JQuery
-foreign import javascript unsafe "jQuery($1)"            jq_selectObject      :: JSVal                          -> IO JQuery
-foreign import javascript unsafe "jQuery($1)"            jq_select            :: JSString                       -> IO JQuery
-foreign import javascript unsafe "jQuery()"              jq_selectEmpty       ::                                   IO JQuery
-foreign import javascript unsafe "jQuery($1,$2)"         jq_selectWithContext :: JSString -> JSVal              -> IO JQuery
-foreign import javascript unsafe "$2.css($1)"            jq_getCss            :: JSString             -> JQuery -> IO JSString
-foreign import javascript unsafe "$3.css($1,$2)"         jq_setCss            :: JSString -> JSString -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.height()"           jq_getHeight         ::                         JQuery -> IO Double
-foreign import javascript unsafe "$2.height($1)"         jq_setHeight         :: Double               -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.width()"            jq_getWidth          ::                         JQuery -> IO Double
-foreign import javascript unsafe "$2.width($1)"          jq_setWidth          :: Double               -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.innerHeight()"      jq_getInnerHeight    ::                         JQuery -> IO Double
-foreign import javascript unsafe "$1.innerWidth()"       jq_getInnerWidth     ::                         JQuery -> IO Double
-foreign import javascript unsafe "$2.outerHeight($1)"    jq_getOuterHeight    :: Bool                 -> JQuery -> IO Double
-foreign import javascript unsafe "$2.outerWidth($1)"     jq_getOuterWidth     :: Bool                 -> JQuery -> IO Double
-foreign import javascript unsafe "$2.trigger($1)"        jq_trigger           :: JSString             -> JQuery -> IO ()
-foreign import javascript unsafe "$2.triggerHandler($1)" jq_triggerHandler    :: JSString             -> JQuery -> IO ()
-foreign import javascript unsafe "$1.scrollLeft()"       jq_getScrollLeft     ::                         JQuery -> IO Double
-foreign import javascript unsafe "$2.scrollLeft($1)"     jq_setScrollLeft     :: Double               -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.scrollTop()"        jq_getScrollTop      ::                         JQuery -> IO Double
-foreign import javascript unsafe "$2.scrollTop($1)"      jq_setScrollTop      :: Double               -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.stop($1)"           jq_stop              :: Bool                 -> JQuery -> IO JQuery
-foreign import javascript unsafe "$1.focus()"            jq_focus             ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "jQuery(document).ready($1)"  jq_ready             ::                     Callback a -> IO ()
+foreign import javascript unsafe "$2.addClass($1)"             jq_addClass          :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$3.animate($1,$2)"           jq_animate           :: JSVal    -> JSVal    -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.attr($1)"                 jq_getAttr           :: JSString             -> JQuery -> IO JSString
+foreign import javascript unsafe "$3.attr($1,$2)"              jq_setAttr           :: JSString -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.hasClass($1)"             jq_hasClass          :: JSString             -> JQuery -> IO Bool
+foreign import javascript unsafe "$1.html()"                   jq_getHtml           ::                         JQuery -> IO JSString
+foreign import javascript unsafe "$2.html($1)"                 jq_setHtml           :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.prop($1)"                 jq_getProp           :: JSString             -> JQuery -> IO JSString
+foreign import javascript unsafe "$3.prop($1,$2)"              jq_setProp           :: JSString -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.removeAttr($1)"           jq_removeAttr        :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.removeClass($1)"          jq_removeClass       :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.removeProp($1)"           jq_removeProp        :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.val()"                    jq_getVal            ::                         JQuery -> IO JSString
+foreign import javascript unsafe "$2.val($1)"                  jq_setVal            :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.text()"                   jq_getText           ::                         JQuery -> IO JSString
+foreign import javascript unsafe "$2.text($1)"                 jq_setText           :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "jQuery.holdReady($1)"        jq_holdReady         :: Bool                           -> IO ()
+foreign import javascript unsafe "jQuery($1)"                  jq_selectElement     :: Element                        -> IO JQuery
+foreign import javascript unsafe "jQuery($1)"                  jq_selectObject      :: JSVal                          -> IO JQuery
+foreign import javascript unsafe "jQuery($1)"                  jq_select            :: JSString                       -> IO JQuery
+foreign import javascript unsafe "jQuery()"                    jq_selectEmpty       ::                                   IO JQuery
+foreign import javascript unsafe "jQuery($1,$2)"               jq_selectWithContext :: JSString -> JSVal              -> IO JQuery
+foreign import javascript unsafe "$2.css($1)"                  jq_getCss            :: JSString             -> JQuery -> IO JSString
+foreign import javascript unsafe "$3.css($1,$2)"               jq_setCss            :: JSString -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.height()"                 jq_getHeight         ::                         JQuery -> IO Double
+foreign import javascript unsafe "$2.height($1)"               jq_setHeight         :: Double               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.width()"                  jq_getWidth          ::                         JQuery -> IO Double
+foreign import javascript unsafe "$2.width($1)"                jq_setWidth          :: Double               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.innerHeight()"            jq_getInnerHeight    ::                         JQuery -> IO Double
+foreign import javascript unsafe "$1.innerWidth()"             jq_getInnerWidth     ::                         JQuery -> IO Double
+foreign import javascript unsafe "$2.outerHeight($1)"          jq_getOuterHeight    :: Bool                 -> JQuery -> IO Double
+foreign import javascript unsafe "$2.outerWidth($1)"           jq_getOuterWidth     :: Bool                 -> JQuery -> IO Double
+foreign import javascript unsafe "$2.trigger($1)"              jq_trigger           :: JSString             -> JQuery -> IO ()
+foreign import javascript unsafe "$2.triggerHandler($1)"       jq_triggerHandler    :: JSString             -> JQuery -> IO ()
+foreign import javascript unsafe "$1.scrollLeft()"             jq_getScrollLeft     ::                         JQuery -> IO Double
+foreign import javascript unsafe "$2.scrollLeft($1)"           jq_setScrollLeft     :: Double               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.scrollTop()"              jq_getScrollTop      ::                         JQuery -> IO Double
+foreign import javascript unsafe "$2.scrollTop($1)"            jq_setScrollTop      :: Double               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.stop($1)"                 jq_stop              :: Bool                 -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.focus()"                  jq_focus             ::                         JQuery -> IO JQuery
 
 foreign import javascript unsafe "jQuery($1.delegateTarget)"          jq_delegateTarget                :: Event -> IO JSVal -- Element
 foreign import javascript unsafe "$1.isDefaultPrevented()"            jq_isDefaultPrevented            :: Event -> IO Bool

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -5,13 +5,25 @@ import JavaScript.JQuery
 import Control.Monad
 import Data.Default
 import Data.IORef
+import Data.JSString.Text
 
 import qualified Data.Text as T
 
-main = do
+main :: IO ()
+main = ready $ do
   myClick <- select "<div>click here</div>"
   myCount <- select "<div>0</div>"
   counter <- newIORef (0::Int)
   let getCount = atomicModifyIORef counter (\c -> let c' = c+1 in (c', T.pack $ show c'))
-  click (\_ -> void $ getCount >>= flip setText myCount) def myClick
-  select "body" >>= appendJQuery myClick >>= appendJQuery myCount
+  click (\_ -> void $ getCount >>= flip (setText . textToJSString) myCount) def myClick
+  select "#counter-area" >>= appendJQuery myClick >>= appendJQuery myCount
+  theBtn <- select "#a-button"
+  theMsg <- select "#a-message"
+  click (\e -> do
+               preventDefault e
+               void $ do
+                 setHtml "Clicked!" theMsg
+                 removeClass "btn-primary" theBtn
+                 addClass "btn-success" theBtn
+        ) def theBtn
+  return ()

--- a/example/build.sh
+++ b/example/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+stack build
+echo "Copy all.js..."
+cp $(stack path --dist-dir)/build/ghcjs-jquery-example/ghcjs-jquery-example.jsexe/all.js example/
+echo "All done."

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>GHCJS JQuery Demo</title>
+    <!-- Our app -->
+    <script type="text/javascript" src="all.js"></script>
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"
+          integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ=="
+          crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
+            integrity="sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ=="
+            crossorigin="anonymous"></script>
+  </head>
+  <body>
+    <div class="container">
+      <div id="counter-area"></div>
+      <br>
+      <a href="#" id="a-button" class="btn btn-primary">Click me</a>
+      <p id="a-message"></p>
+      <br>
+    </div>
+  </body>
+</html>

--- a/ghcjs-jquery.cabal
+++ b/ghcjs-jquery.cabal
@@ -26,3 +26,17 @@ library
 
   default-language:    Haskell2010
   include-dirs: JavaScript/JQuery
+
+executable ghcjs-jquery-example
+  hs-source-dirs: example
+  main-is: Main.hs
+  ghcjs-options: -O2 -Wall
+  if impl(ghcjs)
+    cpp-options: -DGHCJS_BROWSER
+  build-depends:     base >= 4.7 && < 4.9,
+                     data-default,
+                     ghcjs-base,
+                     ghcjs-jquery,
+                     ghcjs-dom > 0.2,
+                     text
+  default-language:  Haskell2010

--- a/jquery/jquery-1.11.1.js
+++ b/jquery/jquery-1.11.1.js
@@ -13,7 +13,6 @@
  */
 
 (function( global, factory ) {
-    if ( h$isNode ) return;
 	if ( typeof module === "object" && typeof module.exports === "object" ) {
 		// For CommonJS and CommonJS-like environments where a proper window is present,
 		// execute the factory and get jQuery

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,17 @@
+resolver: lts-3.14
+compiler: ghcjs-0.2.0.20151029_ghc-7.10.2
+compiler-check: match-exact
+setup-info:
+  ghcjs:
+    source:
+      ghcjs-0.2.0.20151029_ghc-7.10.2:
+        url: "https://github.com/nrolland/ghcjs/releases/download/v0.2.0.20151029/ghcjs-0.2.0.20151029.tar.gz"
+
+packages:
+- '.'
+
+extra-deps:
+  - ghcjs-dom-0.2.3.0
+
+flags: {}
+extra-package-dbs: []


### PR DESCRIPTION
cc @mgsloan @luite 

Hey folks,

This is my tentative fix for #14 (adding `ready` FFI) plus some minor fixes I would like to review with you.
The FFI itself was trivial, but I couldn't not notice that the `Main.hs` example was experiencing a bit of code rotting, as it wasn't compiling anymore after the port to `improved-base`. So I seized the chance to make it prettier (it's pulling the Bootstrap framework via their CDN):

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/442035/11390302/0f4117ca-9349-11e5-8d0f-b9c34eef95cc.gif)

To make it work I had to also remove the `h$isNode` check inside `jquery.1.11.js` as it was causing the example to choke as that function was not defined anywhere. I have searched for it in some kind of variant but I failed to find anything inside either the `ghcjs` or the `ghcjs-base` repos, so I deduce is now gone? 

On top of that, this is a list of changes delivered by this patch:

* I have added a `stack.yml` file for ease of building with stack
* I have added the `ready` FFI, as per ticket (and I have indeed tested it's working in the `Main.hs`)
* I have added a new executable section in the cabal manifest for the example app
* I have added a `build.sh` script to automatically build the example (and copy `all.js` in the right place)
* I have removed `h$isNode` from the jQuery sources

Last but not least I have feedback on the API ergonomics, but I'm opening a different issue for that.

Thoughts? 